### PR TITLE
Improve button focus styles

### DIFF
--- a/selectRole.js
+++ b/selectRole.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var selectRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-orientation': null
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite'], ['roletype', 'structure', 'section', 'group']]
+};
+var _default = selectRole;
+exports.default = _default;


### PR DESCRIPTION
Enhance focus-visible styles for primary and secondary buttons to improve keyboard accessibility and contrast. Update CSS to use a 3px solid brand outline with increased offset and ensure disabled buttons get a visible but subdued focus state.