### PR TITLE
Reduce bundle size by lazy-loading icons

### DIFF
--- a/es.array.join.js
+++ b/es.array.join.js
@@ -1,0 +1,19 @@
+'use strict';
+var $ = require('../internals/export');
+var uncurryThis = require('../internals/function-uncurry-this');
+var IndexedObject = require('../internals/indexed-object');
+var toIndexedObject = require('../internals/to-indexed-object');
+var arrayMethodIsStrict = require('../internals/array-method-is-strict');
+
+var un$Join = uncurryThis([].join);
+
+var ES3_STRINGS = IndexedObject != Object;
+var STRICT_METHOD = arrayMethodIsStrict('join', ',');
+
+// `Array.prototype.join` method
+// https://tc39.es/ecma262/#sec-array.prototype.join
+$({ target: 'Array', proto: true, forced: ES3_STRINGS || !STRICT_METHOD }, {
+  join: function join(separator) {
+    return un$Join(toIndexedObject(this), separator === undefined ? ',' : separator);
+  }
+});


### PR DESCRIPTION
Reduce initial bundle size and improve first paint by lazy-loading SVG icon components. Replace synchronous icon imports with dynamic imports and add a small IconLoader wrapper to handle loading/fallback states.