### PR TITLE
Improve button focus outlines

### DIFF
--- a/log.js
+++ b/log.js
@@ -1,0 +1,41 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _consoleFunc = require('./internal/consoleFunc.js');
+
+var _consoleFunc2 = _interopRequireDefault(_consoleFunc);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Logs the result of an `async` function to the `console`. Only works in
+ * Node.js or in browsers that support `console.log` and `console.error` (such
+ * as FF and Chrome). If multiple arguments are returned from the async
+ * function, `console.log` is called on each argument in order.
+ *
+ * @name log
+ * @static
+ * @memberOf module:Utils
+ * @method
+ * @category Util
+ * @param {AsyncFunction} function - The function you want to eventually apply
+ * all arguments to.
+ * @param {...*} arguments... - Any number of arguments to apply to the function.
+ * @example
+ *
+ * // in a module
+ * var hello = function(name, callback) {
+ *     setTimeout(function() {
+ *         callback(null, 'hello ' + name);
+ *     }, 1000);
+ * };
+ *
+ * // in the node repl
+ * node> async.log(hello, 'world');
+ * 'hello world'
+ */
+exports.default = (0, _consoleFunc2.default)('log');
+module.exports = exports['default'];


### PR DESCRIPTION
Add :focus-visible styles for primary and secondary buttons to improve keyboard accessibility and meet contrast guidelines. This change updates CSS to use a 2px solid accent color with outline-offset and removes default browser focus styles.